### PR TITLE
Issue #11: Update configuration for read-only DB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,10 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,11 +1,11 @@
 spring.application.name=recommendation-service
-spring.datasource.url=jdbc:h2:file:./transaction
 server.port=8080
+application.recommendations-db.url=jdbc:h2:file:./transaction;MODE=PostgreSQL
 
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
 spring.jpa.hibernate.ddl-auto=none
 spring.sql.init.mode=never
-
-spring.datasource.driver-class-name=org.h2.Driver
 
 logging.level.root=INFO
 logging.level.org.springframework.jdbc.core=DEBUG


### PR DESCRIPTION
## Описание
Обновление конфигурации для работы с read-only базой согласно ТЗ.

## Изменения
- Добавлена зависимость `spring-boot-starter-validation`
- Настроено кастомное свойство `application.recommendations-db.url`
- Удален `spring.datasource.url` для избежания конфликтов
- Добавлена H2 console для отладки
- Соответствует требованиям ТЗ по настройке read-only базы

Closes #11